### PR TITLE
Unpin Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG alpine_version=3.13
+ARG alpine_version=edge
 
 FROM alpine:${alpine_version} as base
 RUN apk update && apk upgrade


### PR DESCRIPTION
Switch back `develop` branch to Alpine `edge`. Most users have updated their docker hosts to a recent version in the meantime.